### PR TITLE
Allow passing options directly to simpleDB

### DIFF
--- a/src/isotopes/client/index.ts
+++ b/src/isotopes/client/index.ts
@@ -132,13 +132,15 @@ export class IsotopeClient {
    *
    * @param domain - SimpleDB domain name
    * @param options - Client options
+   * @param simpleDBOptions - Options to pass directly to SimpleDB constructor
    */
   public constructor(
     protected domain: string,
-    options?: IsotopeClientOptions
+    options?: IsotopeClientOptions,
+    simpleDBOptions?: SimpleDB.ClientConfiguration
   ) {
     this.options  = { ...defaultOptions, ...options }
-    this.simpledb = new SimpleDB({ apiVersion: "2009-04-15" })
+    this.simpledb = new SimpleDB({ ...simpleDBOptions, apiVersion: "2009-04-15" })
   }
 
   /**

--- a/src/isotopes/index.ts
+++ b/src/isotopes/index.ts
@@ -20,6 +20,7 @@
  * IN THE SOFTWARE.
  */
 
+import { SimpleDB } from "aws-sdk"
 import { omit, set } from "lodash/fp"
 
 import {
@@ -33,7 +34,6 @@ import {
 } from "./format"
 import { IsotopeSelect } from "./select"
 import { DeepPartial } from "./utilities"
-import { SimpleDB } from "aws-sdk"
 
 /* ----------------------------------------------------------------------------
  * Types

--- a/src/isotopes/index.ts
+++ b/src/isotopes/index.ts
@@ -33,6 +33,7 @@ import {
 } from "./format"
 import { IsotopeSelect } from "./select"
 import { DeepPartial } from "./utilities"
+import { SimpleDB } from "aws-sdk"
 
 /* ----------------------------------------------------------------------------
  * Types
@@ -109,9 +110,10 @@ export class Isotope<
    * Initialize an isotope
    *
    * @param options - Options
+   * @param simpleDBOptions -- Any configuration to be passed directly to SimpleDB
    */
-  public constructor(protected options: IsotopeOptions<T>) {
-    this.client = new IsotopeClient(options.domain)
+  public constructor(protected options: IsotopeOptions<T>, simpleDBOptions?: SimpleDB.ClientConfiguration) {
+    this.client = new IsotopeClient(options.domain, undefined, simpleDBOptions)
   }
 
   /**


### PR DESCRIPTION
## What I'm doing

Allow users to directly pass configuration options to the SimpleDB constructor (like accessToken, etc)

## Context

I'm using Isotopes for a [sideproject](https://github.com/artsy/studio) at [Artsy](https://github.com/artsy) that I want to deploy to [Zeit's now](zeit.co). Challenge is, they have a [restriction](https://zeit.co/docs/v2/platform/limits/#reserved-variables) on what environment variables can be included in a build... these include AWS credential environment variables. I was looking through [AWS' docs on setting aws credentials in node](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) and it seems like passing in the credentials takes the most precedence (and for my case would be the easiest thing to do). 