### PR TITLE
store a `type` against the entities to allow multiple types to safely …

### DIFF
--- a/src/isotopes/select/index.ts
+++ b/src/isotopes/select/index.ts
@@ -30,8 +30,12 @@ import {
   select,
   Select
 } from "squel"
+import squel = require("squel")
 
 import { IsotopeOptions } from ".."
+
+const typeFilter = (type: string): Expression => squel.expr()
+  .and('`__isotopes_type` = ?', JSON.stringify(type));
 
 /* ----------------------------------------------------------------------------
  * Class
@@ -58,7 +62,7 @@ export class IsotopeSelect<T extends {}> {
     protected query: Select = select({
       autoQuoteTableNames: true,
       autoQuoteFieldNames: true
-    }).from(options.domain)
+    }).from(options.domain).where(isUndefined(options.type) ? '' : typeFilter(options.type))
   ) {}
 
   /**

--- a/tests/suites/unit/isotopes/select/index.spec.ts
+++ b/tests/suites/unit/isotopes/select/index.spec.ts
@@ -22,6 +22,7 @@
 
 import { IsotopeOptions } from "isotopes"
 import { IsotopeSelect } from "isotopes/select"
+import squel from "squel"
 
 import { Data } from "_/mocks/data"
 
@@ -230,6 +231,49 @@ describe("isotopes/select", () => {
             .where("`x` = ?")
           expect(select.toString())
             .toEqual("SELECT * FROM `domain` WHERE (`x` = 'undefined')")
+        })
+      })
+
+      describe("with defined type in options", () => {
+
+        /* Options */
+        const options: IsotopeOptions<Data> = {
+          domain: "domain",
+          key: "id",
+          type: "type"
+        }
+
+        it("should add __isotype_type filter to clause", () => {
+          const select = new IsotopeSelect(options)
+          expect(select.toString())
+            .toEqual("SELECT * FROM `domain` WHERE (`__isotopes_type` = '\"type\"')")
+        })
+
+        it("should append supplied string predicate with AND", () => {
+          const select = new IsotopeSelect(options)
+            .where("`x` = ? or `y` = ?")
+          expect(select.toString())
+            .toEqual("SELECT * FROM `domain` WHERE (`__isotopes_type` = '\"type\"') AND (`x` = 'undefined' or `y` = 'undefined')")
+        })
+
+        it("should append supplied expression prediciate with AND", () => {
+          const predicate = squel.expr()
+            .and('`x` = ?')
+            .or('`y` = ?')
+          const select = new IsotopeSelect(options)
+            .where(predicate)
+          expect(select.toString())
+            .toEqual("SELECT * FROM `domain` WHERE (`__isotopes_type` = '\"type\"') AND (`x` = 'undefined' OR `y` = 'undefined')")
+        })
+
+        it("should append supplied expression prediciate with AND (ignores first OR)", () => {
+          const predicate = squel.expr()
+            .or('`x` = ?')
+            .or('`y` = ?')
+          const select = new IsotopeSelect(options)
+            .where(predicate)
+          expect(select.toString())
+            .toEqual("SELECT * FROM `domain` WHERE (`__isotopes_type` = '\"type\"') AND (`x` = 'undefined' OR `y` = 'undefined')")
         })
       })
     })


### PR DESCRIPTION
…use the same domain

I am using a "hidden" field on the entities that is set during put and removed during get/select

When performing a select it ensures that only the entities of the correct type are returned 